### PR TITLE
added functionality to display bmp images

### DIFF
--- a/5_Multicore/src/bmp/bmp.h
+++ b/5_Multicore/src/bmp/bmp.h
@@ -1,0 +1,43 @@
+// BMP-related data types based on Microsoft's own
+
+#include <stdint.h>
+
+// aliases for C/C++ primitive data types
+// https://msdn.microsoft.com/en-us/library/cc230309.aspx
+typedef uint8_t  BYTE;
+typedef uint32_t DWORD;
+typedef int32_t  LONG;
+typedef uint16_t WORD;
+
+// information about the type, size, and layout of a file
+// https://msdn.microsoft.com/en-us/library/dd183374(v=vs.85).aspx
+typedef struct
+{
+    WORD type;
+    DWORD size;
+    WORD reserved1;
+    WORD reserved2;
+    DWORD offset;
+    DWORD dib_header_size;
+    LONG width_px;
+    LONG height_px;
+    WORD num_planes;
+    WORD bits_per_pixel;
+    DWORD compression;
+    DWORD image_size_bytes;
+    LONG x_resolution_ppm;
+    LONG y_resolution_ppm;
+    DWORD num_colors;
+    DWORD important_colors;
+} __attribute__((__packed__))
+BMP_HEADER;
+
+// relative intensities of red, green, and blue
+// https://msdn.microsoft.com/en-us/library/dd162939(v=vs.85).aspx
+typedef struct
+{
+    BYTE blue;
+    BYTE green;
+    BYTE red;
+} __attribute__((__packed__))
+RGB_COLOR;

--- a/5_Multicore/src/drivers/sd/sd.c
+++ b/5_Multicore/src/drivers/sd/sd.c
@@ -180,7 +180,7 @@ int sd_cmd(unsigned int code, unsigned int arg)
         code &= ~CMD_NEED_APP;
     }
     if(sd_status(SR_CMD_INHIBIT)) { kprintf_debug("ERROR: EMMC busy\n"); sd_err= SD_TIMEOUT;return 0;}
-    kprintf_debug("EMMC: Sending command ");kprintf_debug( "%d", code);kprintf_debug(" arg ");kprintf_debug( "%d", arg);kprintf_debug("\n");
+    // kprintf_debug("EMMC: Sending command ");kprintf_debug( "%d", code);kprintf_debug(" arg ");kprintf_debug( "%d", arg);kprintf_debug("\n");
     *EMMC_INTERRUPT=*EMMC_INTERRUPT; *EMMC_ARG1=arg; *EMMC_CMDTM=code;
     if(code==CMD_SEND_OP_COND) delays_wait_microsecs(1000); else
     if(code==CMD_SEND_IF_COND || code==CMD_APP_CMD) delays_wait_microsecs(100);

--- a/5_Multicore/src/main.c
+++ b/5_Multicore/src/main.c
@@ -4,6 +4,7 @@
 #include "hal.h"
 #include "kprintf.h"
 #include "fat.h"
+#include "bmp.h"
 #define ENTER   10
 #define ESC		27
 #define PREVIOUS 'q'
@@ -166,11 +167,13 @@ void display_file(uint8_t * filename, uint8_t * ext){
 			kprintf( "%s", buffer );
 			kprintf( "\n\n" );
 		} else if(ext[0] == 'B' && ext[1] == 'M' && ext[2] == 'P'){
+			BMP_HEADER header;
+			memcpy(&header, buffer, sizeof(BMP_HEADER));
 			print_n_chars(filename, FAT_MAX_FILENAME_LENGTH);
 			kprintf( "." );
 			print_n_chars(ext, FAT_MAX_EXT_LENGTH);
 			kprintf("(%d KB): \n", file.size/1024 );
-			hal_io_video_draw_image( buffer, 171, 211 );
+			hal_io_video_draw_image( buffer, header.width_px, header.height_px );
 			kprintf( "\n\n" );
 		}
 	}else{

--- a/5_Multicore/src/main_fat_sample.c
+++ b/5_Multicore/src/main_fat_sample.c
@@ -1,144 +1,144 @@
-#include <stdbool.h>		// C standard needed for bool
-#include <stdint.h>			// C standard for uint8_t, uint16_t, uint32_t etc
-#include "system.h"
-#include "hal.h"
-#include "kprintf.h"
-#include "fat.h"
+// #include <stdbool.h>		// C standard needed for bool
+// #include <stdint.h>			// C standard for uint8_t, uint16_t, uint32_t etc
+// #include "system.h"
+// #include "hal.h"
+// #include "kprintf.h"
+// #include "fat.h"
 
 
-//         W A R N I N G:
-//
-//
-//          NOTE THE FILE SYSTEM AND (MULTICORE THREADS + INTERRUPTS )
-//             DON;T WORK TOGETHER AT THE MOMENT
-//
-//
-//           BY ITSELF IT WORKS JUST FINE          
-//
-//
+// //         W A R N I N G:
+// //
+// //
+// //          NOTE THE FILE SYSTEM AND (MULTICORE THREADS + INTERRUPTS )
+// //             DON;T WORK TOGETHER AT THE MOMENT
+// //
+// //
+// //           BY ITSELF IT WORKS JUST FINE          
+// //
+// //
 
-void display_root_dir(void);
-void display_image(void);
-void display_alice(void);
-void print_n_chars();
-
-
-uint8_t buffer[240000]; //107KB (Recall there's 3 pixels per byte + headers)
-
-FATFile file;
-
-int kernel_main (void) {
-
-    system_init();  //This inits everything (should not be removed)
-
-    display_root_dir();
-	display_image();
-	display_alice();
-
-	while (1);
-
-	return 0;
-}
-
-void print_n_chars( uint8_t* str, uint32_t len ){
-	while( len-- > 0 )
-		kprintf( "%c", *str++ );
-}
-
-void display_root_dir(void){
-	//read root dir
-	FATDirectory dir;
-	fat_read_files_in_dir( &dir, "/" );
-
-	//display directory
-	//
-	//   VFAT Long File Names (LFNs) are stored on a FAT file system
-	//	 using a trick: adding additional entries into the directory
-	//	 before the normal file entry. The additional entries are marked
-	//   with the VOLUME LABEL, SYSTEM, HIDDEN, and READ ONLY attributes
-	//	 (yielding 0x0F), which is a combination that is not expected
-	//	 in the MS-DOS environment, and therefore ignored by MS-DOS programs
-	//	 and third-party utilities.
-	//
-	// See https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#VFAT_long_file_names
-	//
-	kprintf( "\n" );
-	kprintf( "ROOT DIRECTORY:\n\n" );
-	for( uint32_t i=0; i<dir.num_of_files; i++ ){
-
-			if( dir.files[i].is_read_only
-				&&  dir.files[i].is_hidden
-				&&  dir.files[i].is_volume
-				&&  dir.files[i].is_system )
-					continue; //Skip VFAT entries
-
-			if( dir.files[i].is_volume
-				|| dir.files[i].is_hidden
-			 	|| dir.files[i].is_system )
-					continue; //Skip Volume, Hidden, and System entries
-
-			print_n_chars( dir.files[i].name, FAT_MAX_FILENAME_LENGTH );
-			kprintf( "   " );
-			print_n_chars( dir.files[i].ext, FAT_MAX_EXT_LENGTH );
-			kprintf( "   " );
-			kprintf( "%d KB",  dir.files[i].size/1024 );
-
-			kprintf( "\n" );
-	}
-
-    hal_video_puts( "\n\nPress any key to continue", 2, VIDEO_COLOR_RED  );
-	hal_io_serial_getc( SerialA );
-	hal_video_clear( SYSTEM_SCREEN_BACKGROUND_COLOR );
-
-}
-
-void display_alice(void){
-
-	FATFile file;
-
-	if( fat_file_open( &file, "ALICE", "TXT" ) == FAT_SUCCESS ){
-
-		//Read to buffer
-		fat_file_read( &file, buffer );
-		buffer[file.size] = '\0';
-
-		//Display
-		kprintf( "ALICE.TXT (%d KB): \n\n", file.size/1024 );
-		kprintf( "\n" );
-		kprintf( "%s", buffer );
-
-		hal_video_puts( "\n\nPress any key to continue", 2, VIDEO_COLOR_RED  );
-		hal_io_serial_getc( SerialA );
-		hal_video_clear( SYSTEM_SCREEN_BACKGROUND_COLOR );
-
-	}else{
-		hal_video_puts( "\nFILE NOT FOUND\n", 2, VIDEO_COLOR_RED );
-	}
-
-}
+// void display_root_dir(void);
+// void display_image(void);
+// void display_alice(void);
+// void print_n_chars();
 
 
-void display_image(void){
+// uint8_t buffer[240000]; //107KB (Recall there's 3 pixels per byte + headers)
 
-	FATFile file;
+// FATFile file;
 
-	if( fat_file_open( &file, "COFFEE2", "BMP" ) ==  FAT_SUCCESS ){
+// int kernel_main (void) {
 
-		//Read to buffer
-		fat_file_read( &file, buffer );
+//     system_init();  //This inits everything (should not be removed)
 
-		//Display
-		kprintf( "\nCOFFEE2.BMP (%d KB): \n", file.size/1024 );
-		hal_io_video_draw_image( buffer, 171, 211 );
-        kprintf( "\n\n" );
+//     display_root_dir();
+// 	display_image();
+// 	display_alice();
 
-		//hal_video_puts( "\n\nPress any key to continue", 2, VIDEO_COLOR_RED  );
-		//hal_io_serial_getc( SerialA );
-		//hal_video_clear();
+// 	while (1);
 
-	}else{
-		hal_video_puts( "\nFILE NOT FOUND\n", 2, VIDEO_COLOR_RED );
-	}
+// 	return 0;
+// }
+
+// void print_n_chars( uint8_t* str, uint32_t len ){
+// 	while( len-- > 0 )
+// 		kprintf( "%c", *str++ );
+// }
+
+// void display_root_dir(void){
+// 	//read root dir
+// 	FATDirectory dir;
+// 	fat_read_files_in_dir( &dir, "/" );
+
+// 	//display directory
+// 	//
+// 	//   VFAT Long File Names (LFNs) are stored on a FAT file system
+// 	//	 using a trick: adding additional entries into the directory
+// 	//	 before the normal file entry. The additional entries are marked
+// 	//   with the VOLUME LABEL, SYSTEM, HIDDEN, and READ ONLY attributes
+// 	//	 (yielding 0x0F), which is a combination that is not expected
+// 	//	 in the MS-DOS environment, and therefore ignored by MS-DOS programs
+// 	//	 and third-party utilities.
+// 	//
+// 	// See https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#VFAT_long_file_names
+// 	//
+// 	kprintf( "\n" );
+// 	kprintf( "ROOT DIRECTORY:\n\n" );
+// 	for( uint32_t i=0; i<dir.num_of_files; i++ ){
+
+// 			if( dir.files[i].is_read_only
+// 				&&  dir.files[i].is_hidden
+// 				&&  dir.files[i].is_volume
+// 				&&  dir.files[i].is_system )
+// 					continue; //Skip VFAT entries
+
+// 			if( dir.files[i].is_volume
+// 				|| dir.files[i].is_hidden
+// 			 	|| dir.files[i].is_system )
+// 					continue; //Skip Volume, Hidden, and System entries
+
+// 			print_n_chars( dir.files[i].name, FAT_MAX_FILENAME_LENGTH );
+// 			kprintf( "   " );
+// 			print_n_chars( dir.files[i].ext, FAT_MAX_EXT_LENGTH );
+// 			kprintf( "   " );
+// 			kprintf( "%d KB",  dir.files[i].size/1024 );
+
+// 			kprintf( "\n" );
+// 	}
+
+//     hal_video_puts( "\n\nPress any key to continue", 2, VIDEO_COLOR_RED  );
+// 	hal_io_serial_getc( SerialA );
+// 	hal_video_clear( SYSTEM_SCREEN_BACKGROUND_COLOR );
+
+// }
+
+// void display_alice(void){
+
+// 	FATFile file;
+
+// 	if( fat_file_open( &file, "ALICE", "TXT" ) == FAT_SUCCESS ){
+
+// 		//Read to buffer
+// 		fat_file_read( &file, buffer );
+// 		buffer[file.size] = '\0';
+
+// 		//Display
+// 		kprintf( "ALICE.TXT (%d KB): \n\n", file.size/1024 );
+// 		kprintf( "\n" );
+// 		kprintf( "%s", buffer );
+
+// 		hal_video_puts( "\n\nPress any key to continue", 2, VIDEO_COLOR_RED  );
+// 		hal_io_serial_getc( SerialA );
+// 		hal_video_clear( SYSTEM_SCREEN_BACKGROUND_COLOR );
+
+// 	}else{
+// 		hal_video_puts( "\nFILE NOT FOUND\n", 2, VIDEO_COLOR_RED );
+// 	}
+
+// }
 
 
-}
+// void display_image(void){
+
+// 	FATFile file;
+
+// 	if( fat_file_open( &file, "COFFEE2", "BMP" ) ==  FAT_SUCCESS ){
+
+// 		//Read to buffer
+// 		fat_file_read( &file, buffer );
+
+// 		//Display
+// 		kprintf( "\nCOFFEE2.BMP (%d KB): \n", file.size/1024 );
+// 		hal_io_video_draw_image( buffer, 171, 211 );
+//         kprintf( "\n\n" );
+
+// 		//hal_video_puts( "\n\nPress any key to continue", 2, VIDEO_COLOR_RED  );
+// 		//hal_io_serial_getc( SerialA );
+// 		//hal_video_clear();
+
+// 	}else{
+// 		hal_video_puts( "\nFILE NOT FOUND\n", 2, VIDEO_COLOR_RED );
+// 	}
+
+
+// }


### PR DESCRIPTION
- added `bmp/bmp.h` to read the header of a bmp file
- fixed the call to `hal_io_video_draw_image` to use height and width obtained from header
- rewrote `hal_io_video_draw_image` to use byte padding and making it dynamic
- commented out kprintf_debug to make the app faster
- commented out `main__fat_sample.c` as it was failing builds